### PR TITLE
all predefined members are optional

### DIFF
--- a/draft-ietf-httpapi-rfc7807bis.md
+++ b/draft-ietf-httpapi-rfc7807bis.md
@@ -170,7 +170,7 @@ Note that this requires each of the subproblems to be similar enough to use the 
 
 ## Members of a Problem Details Object {#members}
 
-A problem details object can have the following members:
+A problem details object can have the following members, all of which are OPTIONAL:
 
 ### "type"
 


### PR DESCRIPTION
adding a clear statement that all members of the problem details object are optional. i guess using the RFC 2119 "OPTIONAL" makes sense in this case.