### PR TITLE
Minor editorial change

### DIFF
--- a/draft-ietf-httpapi-rfc7807bis.md
+++ b/draft-ietf-httpapi-rfc7807bis.md
@@ -200,7 +200,7 @@ Problem detail objects can have the following members. If a member's value type 
 
 ### "type" {#type}
 
-The "type" member is a JSON string containing a URI reference {{URI}} that identifies the problem type. Consumers MUST use the "type" URI (after resolution, if necessary) as the problem's primary identifier.
+The "type" member is a JSON string containing a URI reference {{URI}} that identifies the problem type. Consumers MUST use the "type" URI (after resolution, if necessary) as the problem type's primary identifier.
 
 When this member is not present, its value is assumed to be "about:blank".
 


### PR DESCRIPTION
It seems that saying 

> Consumers MUST use the "type" URI (after resolution, if necessary) as the problem's primary identifier.

could be read as `type` identifying the problem instance rather than identifying the problem type. Here's a minor edit to make this more explicit:

> Consumers MUST use the "type" URI (after resolution, if necessary) as the problem type's primary identifier.

It's not quite clear to me what other identifiers could be (patterns of extension members, maybe?), but that's a different question.